### PR TITLE
Example with parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ Responses are published to `${src}/rpc`, where `${src}` is taken from the reques
 ### Request
 
 Published to `esp8266_DA7E15/rpc`:
-```
+```json
+# without parameters
 { "id": 123, "src": "foo", "method": "Sys.GetInfo"}
+
+# with parameters
+{ "id": 123, "src": "foo", "method": "Config.Set", "params": { "config": { "debug": { "level": 3 } } } }
 ```
 Response will be published to `foo/rpc`.
 


### PR DESCRIPTION
It took me longer than it should have to figure out how to send parameters with the RPC call even though it was quite straight forward. An example in the readme would have saved me a lot of time. I'm clearly not the only one either (see #3).